### PR TITLE
Feature/block inbox

### DIFF
--- a/docs/tutorials/implementing.rst
+++ b/docs/tutorials/implementing.rst
@@ -134,8 +134,50 @@ parameters.
 Check the extended interface methods for advanced use of the alarm mechanism.
 
 
+Open and close edges/links
+--------------------------
+
+The :meth:`NodeAlgorithm.close` and :meth:`NodeAlgorithm.open` methods implement the closing and opening of edges,
+respectively. The arguments are the blocking node and the blocked node. From the call of :meth:`NodeAlgorithm.close`
+until the call of :meth:`NodeAlgorithm.open`, the blocking node will not be able to receive any messages from the
+blocked node. The blocked node will not be notified of the blocking. The blocked node can still send
+messages to the blocking node, and once the edge is opened, the blocking node will receive all the messages sent during
+the blocking period. The blocking node can still send messages to the blocked node.
+
+
+
 Helper functions and the extended interface
 ===========================================
+
+
+Block and unblock messages - Keep in queue and receive later
+------------------------------------------------------------
+
+With the help of some functional programming, the :meth:`NodeAlgorithm.block_inbox` and
+:meth:`NodeAlgorithm.unblock_inbox` methods allow a node to block the reception of messages for any given condition.
+The blocked messages are kept in a queue and will be delivered to the node when the blockade is lifted. The condition
+is a function that receives a message and returns a boolean. If the function returns ``False``, the message will be
+blocked.
+
+The usage is this simple:
+    #. Call :meth:`NodeAlgorithm.block_inbox` with the condition function and store the returned object in the node's memory.
+    #. Call :meth:`NodeAlgorithm.unblock_inbox` with the object returned by the :meth:`NodeAlgorithm.block_inbox` method.
+
+
+.. tip::
+    The condition function can be a lambda function, a function defined in the algorithm class or a function defined
+    outside the algorithm class. One such function could look like this:
+
+    .. code-block:: python
+
+        # Normal function
+        def ignore_message(message: Message):
+            return message.header != 'IGNORE_ME'
+
+        # Lambda function
+        ignore_message = lambda message: message.header != 'IGNORE_ME'
+
+
 
 Alarm management
 ----------------

--- a/pydistsim/algorithm/node_algorithm.py
+++ b/pydistsim/algorithm/node_algorithm.py
@@ -118,7 +118,7 @@ class NodeAlgorithm(BaseAlgorithm):
     "Tuple of statuses that nodes should have at the end of the algorithm."
 
     NODE_WRAPPER_MANAGER_TYPE: type[WrapperManager] = WrapperManager
-    "Type of the node access proxy. Default is :class:`NodeAccess`."
+    "Type of the node wrapper manager. Default is :class:`WrapperManager`."
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -344,6 +344,14 @@ class NodeAlgorithm(BaseAlgorithm):
         """
         Close the inbox of the node for a specific neighbor.
 
+        Implementation detail
+        ---------------------
+
+        The inbox is closed by blocking all messages that have the neighbor as the source.
+        This is done by adding a filter to the inbox that blocks all messages that have the neighbor as the source.
+        To be able to unblock the inbox later, the filter is stored in the node's memory, under the key
+        `__closed_edges_filters__`.
+
         :param node: The node for which the inbox is closed.
         :type node: NodeAccess
         :param neighbor: The neighbor for which the inbox is closed.
@@ -373,6 +381,8 @@ class NodeAlgorithm(BaseAlgorithm):
                 filters = node.memory["__closed_edges_filters__"][neighbor]
                 for filter_fn in filters:
                     node.unbox().unblock_inbox(filter_fn)
+
+                node.memory["__closed_edges_filters__"][neighbor] = []
 
     ### Methods for algorithm evaluation ###
 

--- a/pydistsim/message.py
+++ b/pydistsim/message.py
@@ -4,6 +4,7 @@ This module contains the :class:`Message` class, which is used to represent mess
 
 from copy import copy, deepcopy
 from enum import StrEnum
+from typing import Generic, TypeVar
 
 
 class MetaHeader(StrEnum):
@@ -12,18 +13,21 @@ class MetaHeader(StrEnum):
     ALARM_MESSAGE = "ALARM_MESSAGE"
 
 
-class Message:
+T = TypeVar("T")
+
+
+class Message(Generic[T]):
     """
     The Message class is used to represent messages in the simulation.
 
     :param destination: The destination of the message.
-    :type destination: Any
+    :type destination: T
     :param header: The header of the message.
     :type header: str
     :param data: The data associated with the message.
     :type data: dict
     :param source: The source of the message.
-    :type source: Any
+    :type source: T
     :param meta_header: The meta header of the message.
     :type meta_header: MetaHeader
     :param meta_data: The meta data associated with the message. This is meant to be used by the simulation.
@@ -45,16 +49,16 @@ class Message:
 
     def __init__(
         self,
-        destination=None,
+        destination: T = None,
         header=None,
         data=None,
         **kwargs,
     ):
-        self.destination = destination
+        self.destination: T = destination
         self.header = header or "NO HEADER"
         self.data = data
 
-        self.source = kwargs.get("source", None)
+        self.source: T = kwargs.get("source", None)
         self.meta_header = kwargs.get("meta_header", MetaHeader.NORMAL_MESSAGE)
         self.meta_data = kwargs.get("meta_data", {})
 

--- a/pydistsim/network/node.py
+++ b/pydistsim/network/node.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 from pydistsim.logging import LogLevels, logger
 from pydistsim.network.sensor import CompositeSensor
@@ -9,6 +10,38 @@ if TYPE_CHECKING:
     from pydistsim.message import Message
     from pydistsim.network.network import NetworkType
     from pydistsim.network.sensor import Sensor
+
+
+T = TypeVar("T")
+
+
+class BlockableQueue(list[T]):
+
+    def __init__(self):
+        super().__init__()
+        self._filters: list[Callable[[T], bool]] = []
+
+    def add_block(self, filter_func: Callable[[T], bool]) -> Callable[[T], bool]:
+        self._filters.append(filter_func)
+        return filter_func
+
+    def remove_filter(self, filter_func: Callable[[T], bool]):
+        self._filters.remove(filter_func)
+
+    def pop(self):
+        for i in reversed(range(super().__len__())):
+            if all(f(self[i]) for f in self._filters):
+                return super().pop(i)
+        raise IndexError("pop from empty or blocked list")
+
+    def __iter__(self):
+        return filter(lambda x: all(f(x) for f in self._filters), super().__iter__())
+
+    def __bool__(self):
+        return self.__len__() > 0
+
+    def __len__(self):
+        return len(tuple(iter(self)))
 
 
 class Node(ObserverManagerMixin):
@@ -47,8 +80,8 @@ class Node(ObserverManagerMixin):
         self._commRange = commRange or 100
         self._inboxDelay = True
         self._status = None
-        self.outbox: list["Message"] = []
-        self._inbox: list["Message"] = []
+        self.outbox: BlockableQueue["Message"] = BlockableQueue()
+        self._inbox: BlockableQueue["Message"] = BlockableQueue()
         self.memory = {}
         self.clock = 0
 
@@ -113,11 +146,30 @@ class Node(ObserverManagerMixin):
 
         Clears the outbox, inbox, status, and memory of the node.
         """
-        self.outbox: list["Message"] = []
-        self._inbox: list["Message"] = []
+        self.outbox: BlockableQueue["Message"] = BlockableQueue()
+        self._inbox: BlockableQueue["Message"] = BlockableQueue()
         self._status = None
         self.memory = {}
         self.clock = 0
+
+    def block_inbox(self, filter_func: Callable[["Message"], bool]) -> Callable[["Message"], bool]:
+        """
+        Block messages from being received by the node.
+
+        :param filter_func: The filter function to be used.
+        :type filter_func: function
+        :return: The filter function.
+        """
+        return self._inbox.add_block(filter_func)
+
+    def unblock_inbox(self, filter_func: Callable[["Message"], bool]):
+        """
+        Unblock messages from being received by the node.
+
+        :param filter_func: The filter function to be removed.
+        :type filter_func: function
+        """
+        self._inbox.remove_filter(filter_func)
 
     def receive(self):
         """

--- a/pydistsim/network/node.py
+++ b/pydistsim/network/node.py
@@ -153,7 +153,7 @@ class Node(ObserverManagerMixin):
         """
         return self._inbox
 
-    def push_to_inbox(self, message: "Message"):
+    def push_to_inbox(self, message: "Message[Node]"):
         """
         Push a message to the inbox of the node.
 
@@ -165,7 +165,7 @@ class Node(ObserverManagerMixin):
         logger.debug("Message delivered to {}", self)
         self.notify_observers(ObservableEvents.message_delivered, message)
 
-    def push_to_outbox(self, message: "Message", destination: "Node"):
+    def push_to_outbox(self, message: "Message[Node]", destination: "Node"):
         """
         Push a message to the outbox of the node.
 

--- a/pydistsim/tests/test_inbox_blocking.py
+++ b/pydistsim/tests/test_inbox_blocking.py
@@ -1,0 +1,72 @@
+import unittest
+
+from pydistsim.algorithm import NodeAlgorithm, StatusValues
+from pydistsim.algorithm.node_wrapper import NodeAccess
+from pydistsim.message import Message
+from pydistsim.network import NetworkGenerator
+from pydistsim.simulation import Simulation
+
+
+class TimerAlgorithm(NodeAlgorithm):
+
+    class Status(StatusValues):
+        BLOCKER = "BLOCKER"
+        OTHER = "OTHER"
+
+    def initializer(self):
+        node0 = self.network.nodes_sorted()[0]
+        node0.push_to_inbox(Message(meta_header=NodeAlgorithm.INI))
+        node0.status = self.Status.BLOCKER
+
+        node1 = self.network.nodes_sorted()[1]
+        node1.push_to_inbox(Message(meta_header=NodeAlgorithm.INI))
+        node1.status = self.Status.OTHER
+
+    @Status.OTHER
+    def spontaneously(self, node: NodeAccess, message: Message):
+        n = tuple(node.neighbors())[0]
+
+        self.send(node, 1, n, "ONE")
+        self.send(node, 2, n, "TWO")
+        self.send(node, 3, n, "THREE")
+        self.send(node, 4, n, "FOUR")
+
+    @Status.BLOCKER
+    def spontaneously(self, node: NodeAccess, message: Message):
+        n = tuple(node.neighbors())[0]
+
+        self.close(node, n)
+        self.block_inbox(node, lambda m: m.header != "FOUR")
+        self.block_inbox(node, lambda m: m.data != 1)
+        node.memory["ALARM"] = False
+        self.set_alarm(node, 3)
+
+    @Status.BLOCKER
+    def alarm(self, node: NodeAccess, message: Message):
+        n = tuple(node.neighbors())[0]
+        node.memory["ALARM"] = True
+        self.open(node, n)
+
+    @Status.BLOCKER
+    def receiving(self, node: NodeAccess, message: Message):
+        print(message)
+
+        assert node.memory["ALARM"]
+        node.memory[f"RECEIVED_{node.clock}"] = str(message.data)
+
+
+class TestMsgBlocking(unittest.TestCase):
+
+    def test_blocking(self):
+        self.net = NetworkGenerator.generate_complete_network(2)
+        sim = Simulation(self.net)
+        sim.algorithms = (TimerAlgorithm,)
+
+        sim.run()
+
+        for node in self.net.nodes():
+            if node.status == TimerAlgorithm.Status.BLOCKER:
+                assert "1" not in node.memory.values()
+                assert "4" not in node.memory.values()
+                assert "2" in node.memory.values()
+                assert "3" in node.memory.values()


### PR DESCRIPTION
This pull request introduces new functionalities and improvements to the `NodeAlgorithm` class, including methods for blocking and unblocking messages and managing edges. The changes also include updates to the `Message` class to support generic types, enhancements to the `Node` class, and the addition of a new test for inbox blocking.

### New Functionalities and Improvements:

* **Blocking and Unblocking Messages:**
  - Added `block_inbox` and `unblock_inbox` methods to `NodeAlgorithm` to allow nodes to block and unblock messages based on a condition. (`pydistsim/algorithm/node_algorithm.py`)
  - Implemented `BlockableQueue` class in `Node` to manage blocked messages. (`pydistsim/network/node.py`) [[1]](diffhunk://#diff-f704f7e3a468e150de81eb9e476b0068f7fce857b797d894fb05e10464d5fcdbR15-R46) [[2]](diffhunk://#diff-f704f7e3a468e150de81eb9e476b0068f7fce857b797d894fb05e10464d5fcdbL50-R84)

* **Edge Management:**
  - Introduced `close` and `open` methods in `NodeAlgorithm` for closing and opening edges between nodes. (`pydistsim/algorithm/node_algorithm.py`)

### Code Enhancements:

* **Generic Types in Message Class:**
  - Updated the `Message` class to use generic types for `source` and `destination`. (`pydistsim/message.py`) [[1]](diffhunk://#diff-466b8ee4414852b1adda12f7b882b0e48da736cbb086d7261806308e2f589547L15-R30) [[2]](diffhunk://#diff-466b8ee4414852b1adda12f7b882b0e48da736cbb086d7261806308e2f589547L48-R61)

### Documentation:

* **Tutorial Updates:**
  - Added sections in the tutorial to explain the new `close`, `open`, `block_inbox`, and `unblock_inbox` methods. (`docs/tutorials/implementing.rst`)

### Testing:

* **Inbox Blocking Test:**
  - Added a new test case to verify the functionality of message blocking and unblocking in `NodeAlgorithm`. (`pydistsim/tests/test_inbox_blocking.py`)