### PR TITLE
Network -> DirectedNetwork class rename

### DIFF
--- a/docs/reference/networkbehavior.rst
+++ b/docs/reference/networkbehavior.rst
@@ -16,7 +16,7 @@ class defines the three parameters that are used to model the communication prop
    #. How fast a node can process a message. This is used to model the case where a node can only process a certain
       number of messages per time unit.
 
-To apply these properties to a network, simply set :attr:`Network.behavioral_properties` to an instance of
+To apply these properties to a network, simply set :attr:`NetworkType.behavioral_properties` to an instance of
 :class:`NetworkBehaviorModel`.
 
 

--- a/docs/reference/networkmixin.rst
+++ b/docs/reference/networkmixin.rst
@@ -11,7 +11,7 @@ PyDistSim uses the library :mod:`networkx` to represent graphs. :mod:`networkx` 
 In order to extend the defined :class:`networkx.Graph` and :class:`networkx.DiGraph` in :mod:`networkx`, PyDistSim uses a mixin class.
 
 This mixin class is called NetworkMixin and is defined in the network module.
-For the development of the framework, we have used this mixin to define :class:`Network` and :class:`BidirectionalNetwork`,
+For the development of the framework, we have used this mixin to define :class:`DirectedNetwork` and :class:`BidirectionalNetwork`,
 which are subclasses of :class:`networkx.Graph` and :class:`networkx.DiGraph` respectively.
 
 In broad terms, these NetworkMixin subclasses are responsible for the following:
@@ -23,5 +23,5 @@ In broad terms, these NetworkMixin subclasses are responsible for the following:
 
 For class and method documentation refer to :class:`NetworkMixin`.
 
-.. inheritance-diagram:: Network BidirectionalNetwork
-   :caption: Inheritance diagram for Network and BidirectionalNetwork
+.. inheritance-diagram:: DirectedNetwork BidirectionalNetwork
+   :caption: Inheritance diagram for DirectedNetwork and BidirectionalNetwork

--- a/docs/reference/observers.rst
+++ b/docs/reference/observers.rst
@@ -28,7 +28,7 @@ Standardize the use of observers in the framework, we implemented a mixin class 
 can be used to add observer functionality to any class. The mixin class provides methods to add and remove observers,
 and to notify the observers of changes in the observable object.
 
-.. inheritance-diagram:: ObserverManagerMixin pydistsim.algorithm.BaseAlgorithm pydistsim.simulation.Simulation pydistsim.network.network.Network pydistsim.network.network.BidirectionalNetwork pydistsim.network.node.Node
+.. inheritance-diagram:: ObserverManagerMixin pydistsim.algorithm.BaseAlgorithm pydistsim.simulation.Simulation pydistsim.network.network.DirectedNetwork pydistsim.network.network.BidirectionalNetwork pydistsim.network.node.Node
    :top-classes: ObserverManagerMixin
    :parts: 1
    :caption: ObserverManagerMixin inheritance diagram

--- a/pydistsim/__init__.py
+++ b/pydistsim/__init__.py
@@ -31,7 +31,12 @@ from pkgutil import extend_path  # @Reimport
 from pydistsim.algorithm import NodeAlgorithm, StatusValues
 from pydistsim.benchmark import AlgorithmBenchmark
 from pydistsim.logging import disable_logger, enable_logger, logger
-from pydistsim.network import BidirectionalNetwork, Network, NetworkGenerator, Node
+from pydistsim.network import (
+    BidirectionalNetwork,
+    DirectedNetwork,
+    NetworkGenerator,
+    Node,
+)
 from pydistsim.simulation import Simulation
 
 __path__ = extend_path(__path__, __name__)  # @ReservedAssignment

--- a/pydistsim/algorithm/base_algorithm.py
+++ b/pydistsim/algorithm/base_algorithm.py
@@ -88,7 +88,7 @@ class BaseAlgorithm(ObserverManagerMixin, metaclass=AlgorithmMeta):
         required_params = ('rp1',)
         default_params = {'dp1': 'dv1',}
 
-    >>> net = Network()
+    >>> net = DirectedNetwork()
     >>> alg = SomeAlgorithm(net, rp1='rv1')
     >>> alg.rp1
     'rv1'

--- a/pydistsim/benchmark.py
+++ b/pydistsim/benchmark.py
@@ -15,13 +15,13 @@ from pydistsim.logging import logger
 from pydistsim.metrics import MetricCollector
 from pydistsim.network.behavior import NetworkBehaviorModel
 from pydistsim.network.generator import NetworkGenerator
-from pydistsim.network.network import BidirectionalNetwork, Network, NetworkType
+from pydistsim.network.network import BidirectionalNetwork, DirectedNetwork, NetworkType
 from pydistsim.simulation import AlgorithmsParam, Simulation
 
 
 def decide_directed_class(directed: bool):
     if directed:
-        return Network
+        return DirectedNetwork
     else:
         return BidirectionalNetwork
 

--- a/pydistsim/gui/drawing.py
+++ b/pydistsim/gui/drawing.py
@@ -366,7 +366,7 @@ def draw_current_state(
     Automatically determines the current algorithm and draws the network accordingly. This includes a mapping of
     node colors to the status of the nodes, as well as the messages in the network.
 
-    :param sim: Simulation or Network object
+    :param sim: Simulation or NetworkType object
     :param axes: matplotlib axes object
     :param clear: boolean to clear the axes before drawing
     :param tree_key: key in nodes memory (dictionary) where tree data is stored

--- a/pydistsim/network/__init__.py
+++ b/pydistsim/network/__init__.py
@@ -7,7 +7,7 @@ This module contains classes for representing networks and generating networks.
 from pydistsim.network.generator import NetworkGenerator, NetworkGeneratorException
 from pydistsim.network.network import (
     BidirectionalNetwork,
-    Network,
+    DirectedNetwork,
     NetworkException,
     NetworkType,
 )

--- a/pydistsim/network/generator.py
+++ b/pydistsim/network/generator.py
@@ -6,7 +6,7 @@ from numpy import array, cos, log2, pi, sign, sin, sqrt
 from numpy.random import rand
 
 from pydistsim.logging import logger
-from pydistsim.network.network import BidirectionalNetwork, Network
+from pydistsim.network.network import BidirectionalNetwork, DirectedNetwork
 from pydistsim.network.node import Node
 from pydistsim.network.rangenetwork import BidirectionalRangeNetwork, RangeNetwork
 
@@ -303,7 +303,7 @@ class NetworkGenerator:
             >>> net1 = NetworkGenerator.generate_complete_network(5)
             <BidirectionalNetwork object with 5 nodes and 10 edges>
             >>> net2 = NetworkGenerator.generate_complete_network(5, directed_network=True)
-            <Network object with 5 nodes and 20 edges>
+            <DirectedNetwork object with 5 nodes and 20 edges>
             >>> net3 = NetworkGenerator.generate_complete_network(5, network_type=BidirectionalNetwork)
             <BidirectionalNetwork object with 5 nodes and 10 edges>
 
@@ -322,7 +322,7 @@ class NetworkGenerator:
             directed_network = False
 
         if network_type is None:
-            network_type = Network if directed_network else BidirectionalNetwork
+            network_type = DirectedNetwork if directed_network else BidirectionalNetwork
 
         net = network_type()
         node_pos_list = cls.__get_ring_pos(n, net.environment)
@@ -349,7 +349,7 @@ class NetworkGenerator:
             >>> net = NetworkGenerator.generate_ring_network(6)
             <BidirectionalNetwork object with 6 nodes and 6 edges>
             >>> net = NetworkGenerator.generate_ring_network(6, directed_network=False)
-            <Network object with 6 nodes and 6 edges>
+            <DirectedNetwork object with 6 nodes and 6 edges>
 
         DO NOT instantiate the class, this is a class method.
 
@@ -366,7 +366,7 @@ class NetworkGenerator:
             directed_network = False
 
         if network_type is None:
-            network_type = Network if directed_network else BidirectionalNetwork
+            network_type = DirectedNetwork if directed_network else BidirectionalNetwork
 
         net = network_type()
         node_pos_list = cls.__get_ring_pos(n, net.environment)
@@ -409,7 +409,7 @@ class NetworkGenerator:
             directed_network = False
 
         if network_type is None:
-            network_type = Network if directed_network else BidirectionalNetwork
+            network_type = DirectedNetwork if directed_network else BidirectionalNetwork
 
         net = network_type()
         node_pos_list = cls.__get_ring_pos(n - 1, net.environment)
@@ -447,7 +447,7 @@ class NetworkGenerator:
             >>> net = NetworkGenerator.generate_hypercube_network(dimension=3)
             <BidirectionalNetwork object with 8 nodes and 12 edges>
             >>> net2 = NetworkGenerator.generate_hypercube_network(dimension=3, directed_network=True)
-            <Network object with 8 nodes and 24 edges>
+            <DirectedNetwork object with 8 nodes and 24 edges>
             >>> net3 = NetworkGenerator.generate_complete_network(n=8)
             <BidirectionalNetwork object with 8 nodes and 12 edges>
 
@@ -477,7 +477,7 @@ class NetworkGenerator:
             directed_network = False
 
         if network_type is None:
-            network_type = Network if directed_network else BidirectionalNetwork
+            network_type = DirectedNetwork if directed_network else BidirectionalNetwork
 
         LABEL_KEY = "HYPERCUBE_LABEL"
 
@@ -616,7 +616,7 @@ class NetworkGenerator:
             directed_network = False
 
         if network_type is None:
-            network_type = Network if directed_network else BidirectionalNetwork
+            network_type = DirectedNetwork if directed_network else BidirectionalNetwork
 
         if a is None or b is None:
             if n is None:

--- a/pydistsim/network/network.py
+++ b/pydistsim/network/network.py
@@ -34,7 +34,7 @@ class NetworkMixin(ObserverManagerMixin, with_typehint(Graph)):
     """
     Mixin to extend Graph and DiGraph. The result represents a network in a distributed simulation.
 
-    The Network classes (:class:`Network` and :class:`BidirectionalNetwork`) extend the Graph class and provides additional functionality
+    The Network classes (:class:`DirectedNetwork` and :class:`BidirectionalNetwork`) extend the Graph class and provides additional functionality
     for managing nodes and network properties.
 
     :param environment: The environment in which the network operates. If not provided, a new Environment instance will be created.
@@ -64,7 +64,7 @@ class NetworkMixin(ObserverManagerMixin, with_typehint(Graph)):
 
     @staticmethod
     def to_directed_class():
-        return Network
+        return DirectedNetwork
 
     @staticmethod
     def to_undirected_class():
@@ -269,14 +269,14 @@ class NetworkMixin(ObserverManagerMixin, with_typehint(Graph)):
         edges: None | Iterable[tuple[Node, Node]] = None,
     ):
         """
-        Returns a Network instance with the specified nodes and edges.
+        Returns a NetworkType instance with the specified nodes and edges.
 
         :param nbunch: A list of nodes to include in the subnetwork.
         :type nbunch: list[Node]
         :param edges: A list of edges to include in the subnetwork. Defaults to None.
         :type edges: Iterable[tuple[Node, Node]], optional
-        :return: A Network instance representing the subnetwork.
-        :rtype: Network
+        :return: A NetworkType instance representing the subnetwork.
+        :rtype: NetworkType
         """
 
         return self.__deepcopy__({}, nodes, edges)
@@ -649,7 +649,7 @@ class NetworkMixin(ObserverManagerMixin, with_typehint(Graph)):
                             assert sensor.probabilityFunction.scale == value
 
 
-class Network(NetworkMixin, DiGraph):
+class DirectedNetwork(NetworkMixin, DiGraph):
     """
     A directed graph representing a network in a distributed simulation.
     """
@@ -661,5 +661,5 @@ class BidirectionalNetwork(NetworkMixin, Graph):
     """
 
 
-NetworkType = Network | BidirectionalNetwork
+NetworkType = DirectedNetwork | BidirectionalNetwork
 "A network in a distributed simulation."

--- a/pydistsim/network/node.py
+++ b/pydistsim/network/node.py
@@ -49,7 +49,7 @@ class Node(ObserverManagerMixin):
     Represents a node in a network.
 
     :param network: Optional network object to which the node belongs.
-    :type network: Network, optional
+    :type network: NetworkType, optional
     :param commRange: Communication range of the node.
     :type commRange: int, optional
     :param sensors: Tuple of sensor types or names.

--- a/pydistsim/network/rangenetwork.py
+++ b/pydistsim/network/rangenetwork.py
@@ -7,7 +7,7 @@ from numpy.random import random
 
 from pydistsim.logging import logger
 from pydistsim.network.environment import Environment
-from pydistsim.network.network import BidirectionalNetwork, Network
+from pydistsim.network.network import BidirectionalNetwork, DirectedNetwork
 from pydistsim.utils.helpers import with_typehint
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class RangeType(ABC):
         are within communication range.
 
         :param network: The network in which the nodes are connected.
-        :type network: Network
+        :type network: RangeNetworkType
         :param node1: The first node.
         :type node1: Node
         :param node2: The second node.
@@ -65,7 +65,7 @@ class UdgRangeType(RangeType):
         positioned so that their distance is smaller than the communication range.
 
         :param network: The network in which the nodes are connected.
-        :type network: Network
+        :type network: RangeNetworkType
         :param node1: The first node.
         :type node1: Node
         :param node2: The second node.
@@ -99,7 +99,7 @@ class CompleteRangeType(RangeType):
         communication range.
 
         :param network: The network in which the nodes are connected.
-        :type network: Network
+        :type network: RangeNetworkType
         :param node1: The first node.
         :type node1: Node
         :param node2: The second node.
@@ -129,7 +129,7 @@ class SquareDiscRangeType(RangeType):
         probability of connection.
 
         :param network: The network in which the nodes are connected.
-        :type network: Network
+        :type network: RangeNetworkType
         :param node1: The first node.
         :type node1: Node
         :param node2: The second node.
@@ -147,7 +147,7 @@ class SquareDiscRangeType(RangeType):
         return False
 
 
-class RangeNetworkMixin(with_typehint(Network)):
+class RangeNetworkMixin(with_typehint(DirectedNetwork)):
     """
     Mixin to define a type of network that decides which nodes are connected based on their
     communication range.
@@ -295,7 +295,7 @@ class RangeNetworkMixin(with_typehint(Network)):
         logger.trace("Modified degree to {}", self.avg_degree())
 
 
-class RangeNetwork(RangeNetworkMixin, Network):
+class RangeNetwork(RangeNetworkMixin, DirectedNetwork):
     """
     Type of network that decides which nodes are connected based on their communication range.
 

--- a/pydistsim/tests/test_network.py
+++ b/pydistsim/tests/test_network.py
@@ -8,7 +8,7 @@ from pydistsim.network import (
     BidirectionalNetwork,
     BidirectionalRangeNetwork,
     CompleteRangeType,
-    Network,
+    DirectedNetwork,
     NetworkException,
     NetworkType,
     Node,

--- a/pydistsim/tests/test_npickle.py
+++ b/pydistsim/tests/test_npickle.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from pydistsim.demo_algorithms.broadcast import Flood
-from pydistsim.network import Network, NetworkGenerator, NetworkType
+from pydistsim.network import DirectedNetwork, NetworkGenerator, NetworkType
 from pydistsim.utils.npickle import read_npickle, write_npickle
 
 
@@ -23,7 +23,7 @@ class TestPickle(unittest.TestCase):
 
     def test_write_read(self):
         for i, (size, net) in enumerate(self.nets):
-            net: Network
+            net: DirectedNetwork
             with self.subTest(net=net):
                 try:
                     write_npickle(net, f"net_test_{i}.tar.gz")

--- a/pydistsim/tests/test_restrictions.py
+++ b/pydistsim/tests/test_restrictions.py
@@ -3,7 +3,7 @@
 from pydistsim.message import Message
 from pydistsim.network import NetworkGenerator
 from pydistsim.network.behavior import NetworkBehaviorModel
-from pydistsim.network.network import Network
+from pydistsim.network.network import DirectedNetwork
 from pydistsim.restrictions.communication import (
     BidirectionalLinks,
     MessageOrdering,
@@ -81,7 +81,7 @@ class TestRestrictions(PyDistSimTestCase):
         assert not MessageOrdering.check(net)
 
     def test_ReciprocalCommunication(self):
-        net = Network()  # directed graph
+        net = DirectedNetwork()  # directed graph
         n1, n2, n3 = net.add_node(), net.add_node(), net.add_node()
 
         net.add_edge(n1, n2)
@@ -217,7 +217,7 @@ class TestRestrictions(PyDistSimTestCase):
         net = NetworkGenerator(10, enforce_connected=True).generate_random_network()
         assert Connectivity.check(net)
 
-        net = Network()
+        net = DirectedNetwork()
         net.add_node()
         net.add_node()
         assert not Connectivity.check(net)
@@ -238,7 +238,7 @@ class TestRestrictions(PyDistSimTestCase):
         assert UniqueInitiator.check(net)
 
     def test_CompleteGraph(self):
-        net = Network()
+        net = DirectedNetwork()
 
         nodes = [net.add_node() for _ in range(10)]
         for i, n1 in enumerate(nodes):
@@ -252,7 +252,7 @@ class TestRestrictions(PyDistSimTestCase):
         assert not CompleteGraph.check(net)
 
     def test_CycleGraph(self):
-        net = Network()
+        net = DirectedNetwork()
         LEN = 10
         nodes = [net.add_node() for _ in range(LEN)]
         for i, n1 in enumerate(nodes):
@@ -261,7 +261,7 @@ class TestRestrictions(PyDistSimTestCase):
 
         assert CycleGraph.check(net)
 
-        net = Network()
+        net = DirectedNetwork()
         nodes = [net.add_node() for _ in range(LEN)]
         for i, n1 in enumerate(nodes[:-2]):
             n2 = nodes[(i + 1) % LEN]
@@ -270,7 +270,7 @@ class TestRestrictions(PyDistSimTestCase):
         assert not CycleGraph.check(net)
 
     def test_TreeGraph(self):
-        net = Network()
+        net = DirectedNetwork()
         n1, n2, n3, n4, n5 = net.add_node(), net.add_node(), net.add_node(), net.add_node(), net.add_node()
 
         net.add_edge(n1, n2), net.add_edge(n1, n3), net.add_edge(n2, n4), net.add_edge(n2, n5)
@@ -280,7 +280,7 @@ class TestRestrictions(PyDistSimTestCase):
         assert not TreeGraph.check(net)
 
     def test_StarGraph(self):
-        net = Network()
+        net = DirectedNetwork()
         n1, n2, n3, n4, n5 = net.add_node(), net.add_node(), net.add_node(), net.add_node(), net.add_node()
 
         net.add_edge(n1, n2), net.add_edge(n1, n3), net.add_edge(n1, n4)

--- a/pydistsim/tests/test_sensor.py
+++ b/pydistsim/tests/test_sensor.py
@@ -2,7 +2,7 @@ import unittest
 
 import scipy.stats
 
-from pydistsim.network import Network, Node
+from pydistsim.network import DirectedNetwork, Node
 from pydistsim.network.sensor import DistSensor, SensorError
 
 
@@ -10,7 +10,7 @@ class TestSensor(unittest.TestCase):
 
     def test_read(self):
         """Test read compositeSensor"""
-        net = Network()
+        net = DirectedNetwork()
         node = net.add_node()
         node.compositeSensor.read()
 
@@ -21,7 +21,7 @@ class TestSensor(unittest.TestCase):
         node.compositeSensor = ("AoASensor", dist_sensor)
         self.assertRaises(SensorError, node.compositeSensor.read)
 
-        net = Network()
+        net = DirectedNetwork()
         node = net.add_node()
         dist_sensor = DistSensor({"pf": scipy.stats.norm, "scale": 10})
         node.compositeSensor = ("AoASensor", dist_sensor)

--- a/pydistsim/tests/test_utils_tree.py
+++ b/pydistsim/tests/test_utils_tree.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pydistsim.network import CompleteRangeType, Network
+from pydistsim.network import CompleteRangeType, DirectedNetwork
 from pydistsim.network.environment import Environment2D
 from pydistsim.utils import tree, visualization
 
@@ -10,7 +10,7 @@ class TestNetwork(unittest.TestCase):
 
     def setUp(self):
         env = Environment2D()
-        self.net = Network(rangeType=CompleteRangeType(env))
+        self.net = DirectedNetwork(rangeType=CompleteRangeType(env))
         self.net.environment.image[22, 22] = 0
         self.node1 = self.net.add_node(pos=[22.8, 21.8])
         self.node2 = self.net.add_node(pos=[21.9, 22.9])
@@ -34,7 +34,7 @@ class TestNetwork(unittest.TestCase):
 
     def test_not_tree_network(self):
         env = Environment2D()
-        net = Network(rangeType=CompleteRangeType(env))
+        net = DirectedNetwork(rangeType=CompleteRangeType(env))
 
         with self.assertRaises(tree.TreeNetworkException):
             tree.check_tree_key(net, self.tree_key)
@@ -64,7 +64,7 @@ class TestNetwork(unittest.TestCase):
         visualization.show_mst(self.net, self.tree_key)
 
         env = Environment2D()
-        net = Network(rangeType=CompleteRangeType(env))
+        net = DirectedNetwork(rangeType=CompleteRangeType(env))
         node1 = net.add_node(pos=[22.8, 21.8])
 
         node1.memory[self.tree_key] = {


### PR DESCRIPTION
This pull request includes several changes to standardize the terminology and class usage for directed networks in the PyDistSim framework. The most important changes involve renaming `Network` to `DirectedNetwork` and updating references across multiple files to reflect this change.

### Terminology Standardization:

* [`docs/reference/networkbehavior.rst`](diffhunk://#diff-25b737cf7d5fa24b096ccd7f9203c93e37e6596aa1f91a1a8b3c443a19a23c80L19-R19): Updated reference from `Network` to `NetworkType` to apply behavioral properties.
* [`docs/reference/networkmixin.rst`](diffhunk://#diff-32bca248af10cb841762473f8718a09206b6c68ee072ceedfb66bb1aba6978f6L14-R14): Changed `Network` to `DirectedNetwork` in class definitions and inheritance diagrams. [[1]](diffhunk://#diff-32bca248af10cb841762473f8718a09206b6c68ee072ceedfb66bb1aba6978f6L14-R14) [[2]](diffhunk://#diff-32bca248af10cb841762473f8718a09206b6c68ee072ceedfb66bb1aba6978f6L26-R27)
* [`docs/reference/observers.rst`](diffhunk://#diff-1373023e7bdacb10fa549a0ea5ed2162eb81e21f5c364ec4177967c2eb993402L31-R31): Updated inheritance diagram to replace `Network` with `DirectedNetwork`.

### Codebase Updates:

* [`pydistsim/__init__.py`](diffhunk://#diff-bbbd0c8798e770db4143d884f7868f4391e5b6ef6f4434f54cc5ce6942aeab90L34-R39): Replaced `Network` with `DirectedNetwork` in imports.
* [`pydistsim/algorithm/base_algorithm.py`](diffhunk://#diff-7eb379ac6255fb68573555fa0531efc1e4a2d5d21060d73f35bedda2328f14a7L91-R91): Changed example instantiation from `Network` to `DirectedNetwork`.
* [`pydistsim/benchmark.py`](diffhunk://#diff-a62bf0c871ff748e7714ccb31c3ccbfd6bd64ca6b12146f45861dc30e102d671L18-R24): Updated imports and function return type from `Network` to `DirectedNetwork`.
* [`pydistsim/network/network.py`](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL37-R37): Renamed `Network` class to `DirectedNetwork` and updated related references. [[1]](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL37-R37) [[2]](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL67-R67) [[3]](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL272-R279) [[4]](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL652-R652) [[5]](diffhunk://#diff-8e4ece9149458d65bc3863a1fcac5d345b30864ca321f5d38a7550876b10c26cL664-R664)

### Network Generation:

* [`pydistsim/network/generator.py`](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L9-R9): Updated network generation methods to use `DirectedNetwork` instead of `Network`. [[1]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L9-R9) [[2]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L306-R306) [[3]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L325-R325) [[4]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L352-R352) [[5]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L369-R369) [[6]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L412-R412) [[7]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L450-R450) [[8]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L480-R480) [[9]](diffhunk://#diff-92b8c8b93999962a5e825b1d137ae469e7fe12b0761cc58a3953ae6cb76654c5L619-R619)

### Range Network:

* [`pydistsim/network/rangenetwork.py`](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L10-R10): Changed references from `Network` to `DirectedNetwork` and updated type hints. [[1]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L10-R10) [[2]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L39-R39) [[3]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L68-R68) [[4]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L102-R102) [[5]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L132-R132) [[6]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L150-R150) [[7]](diffhunk://#diff-6c5a941fce8fddebe18bac64cb34d13e12b5696799bd5fe3357ea8083e893475L298-R298)

### Tests:

* [`pydistsim/tests/test_network.py`](diffhunk://#diff-765c6dde0dd9a051c0f32ac8ad362f230da6b529e4a073d69e9d7b4273a49c7bL11-R11): Updated imports to replace `Network` with `DirectedNetwork`.